### PR TITLE
test: module test coverage plugin

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,4 @@
+# Test change to exercise the Module Test Coverage plugin.
 locals {
   is_tf_tool        = var.workflow_tool == "OPEN_TOFU" || var.workflow_tool == "TERRAFORM_FOSS"
   is_terragrunt     = var.workflow_tool == "TERRAGRUNT"


### PR DESCRIPTION
Trivial no-op change to trigger a module test run and validate the Module Test Coverage plugin end-to-end. Safe to close once verified.