### PR TITLE
feat: add tf_vars support via TF_CLI_ARGS_plan environment variable

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -6,3 +6,6 @@ tests:
 
  - name: Kubernetes stack
    project_root: examples/kubernetes
+
+ - name: Stack with tfvars
+   project_root: examples/tfvars

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please open a PR or an issue if you see missing functionality.
 
 ```hcl
 module "ec2_worker_pool_stack" {
-  source = "spacelift-solutions/stack/spacelift"
+  source = "spacelift.io/spacelift-solutions/stacks-module/spacelift"
 
   name                  = "worker-pool-stack"
   description           = "Stack to create a worker pool"
@@ -23,7 +23,6 @@ module "ec2_worker_pool_stack" {
   auto_deploy     = true
   administrative  = true
   allow_promotion = true
-  tf_vars         = "environments/production.tfvars"
   tf_version      = "1.7.1"
   tf_workspace    = "worker-pool"
   workflow_tool   = "OPEN_TOFU"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ module "ec2_worker_pool_stack" {
   auto_deploy     = true
   administrative  = true
   allow_promotion = true
+  tf_vars         = "environments/production.tfvars"
   tf_version      = "1.7.1"
   tf_workspace    = "worker-pool"
   workflow_tool   = "OPEN_TOFU"
@@ -162,6 +163,7 @@ module "ec2_worker_pool_stack" {
 | <a name="input_runner_image"></a> [runner\_image](#input\_runner\_image) | The runner image to use for the stack. Defaults to the latest version. | `string` | `null` | no |
 | <a name="input_space_id"></a> [space\_id](#input\_space\_id) | REQUIRED The ID of the space this stack will be in. | `string` | n/a | yes |
 | <a name="input_terragrunt_config"></a> [terragrunt\_config](#input\_terragrunt\_config) | config for terragrunt in spacelift | <pre>object({<br/>    terraform_version    = string<br/>    terragrunt_version   = string<br/>    use_run_all          = optional(bool)<br/>    use_smart_sanitation = optional(bool)<br/>    tool                 = string<br/>  })</pre> | <pre>{<br/>  "terraform_version": null,<br/>  "terragrunt_version": null,<br/>  "tool": null<br/>}</pre> | no |
+| <a name="input_tf_vars"></a> [tf\_vars](#input\_tf\_vars) | Path to a variable file to use for the stack. Sets the TF\_CLI\_ARGS\_plan environment variable to pass the var-file to OpenTofu/Terraform during plan. Not needed for apply since Spacelift applies the generated plan file. | `string` | `null` | no |
 | <a name="input_tf_version"></a> [tf\_version](#input\_tf\_version) | The version of OpenTofu/Terraform for your stack to use. Defaults to latest. | `string` | `"latest"` | no |
 | <a name="input_tf_workspace"></a> [tf\_workspace](#input\_tf\_workspace) | The workspace to use for the stack. | `string` | `null` | no |
 | <a name="input_vcs"></a> [vcs](#input\_vcs) | VCS integration configuration | <pre>object({<br/>    type       = string<br/>    enterprise = optional(bool, false)<br/>    namespace  = optional(string)<br/>    id         = optional(string)<br/>    url        = optional(string)<br/>  })</pre> | <pre>{<br/>  "type": "GITHUB"<br/>}</pre> | no |

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ module "ec2_worker_pool_stack" {
 
   auto_deploy     = true
   allow_promotion = true
+  tf_vars         = ["environments/production.tfvars"]
   tf_version      = "1.7.1"
   tf_workspace    = "worker-pool"
   workflow_tool   = "OPEN_TOFU"
@@ -169,7 +170,7 @@ module "ec2_worker_pool_stack" {
 | <a name="input_runner_image"></a> [runner\_image](#input\_runner\_image) | The runner image to use for the stack. Defaults to the latest version. | `string` | `null` | no |
 | <a name="input_space_id"></a> [space\_id](#input\_space\_id) | REQUIRED The ID of the space this stack will be in. | `string` | n/a | yes |
 | <a name="input_terragrunt_config"></a> [terragrunt\_config](#input\_terragrunt\_config) | config for terragrunt in spacelift | <pre>object({<br/>    terraform_version    = string<br/>    terragrunt_version   = string<br/>    use_run_all          = optional(bool)<br/>    use_smart_sanitation = optional(bool)<br/>    tool                 = string<br/>  })</pre> | <pre>{<br/>  "terraform_version": null,<br/>  "terragrunt_version": null,<br/>  "tool": null<br/>}</pre> | no |
-| <a name="input_tf_vars"></a> [tf\_vars](#input\_tf\_vars) | Path to a variable file to use for the stack. Sets the TF\_CLI\_ARGS\_plan environment variable to pass the var-file to OpenTofu/Terraform during plan. Not needed for apply since Spacelift applies the generated plan file. | `string` | `null` | no |
+| <a name="input_tf_vars"></a> [tf\_vars](#input\_tf\_vars) | Paths to variable files to use for the stack. Sets the TF\_CLI\_ARGS\_plan environment variable to pass the var-files to OpenTofu/Terraform during plan. Not needed for apply since Spacelift applies the generated plan file. | `list(string)` | `[]` | no |
 | <a name="input_tf_version"></a> [tf\_version](#input\_tf\_version) | The version of OpenTofu/Terraform for your stack to use. Defaults to latest. | `string` | `"latest"` | no |
 | <a name="input_tf_workspace"></a> [tf\_workspace](#input\_tf\_workspace) | The workspace to use for the stack. | `string` | `null` | no |
 | <a name="input_vcs"></a> [vcs](#input\_vcs) | VCS integration configuration | <pre>object({<br/>    type       = string<br/>    enterprise = optional(bool, false)<br/>    namespace  = optional(string)<br/>    id         = optional(string)<br/>    url        = optional(string)<br/>  })</pre> | <pre>{<br/>  "type": "GITHUB"<br/>}</pre> | no |

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -12,6 +12,7 @@ module "ec2_worker_pool_stack" {
 
   auto_deploy     = true
   allow_promotion = true
+  tf_vars         = ["environments/production.tfvars"]
   tf_version      = "1.7.1"
   tf_workspace    = "worker-pool"
   workflow_tool   = "OPEN_TOFU"

--- a/examples/tfvars/main.tf
+++ b/examples/tfvars/main.tf
@@ -5,6 +5,6 @@ module "this" {
   repository_branch = "main"
   name              = "my awesome tfvars stack"
   description       = "module test case for a stack with a variable file"
-  tf_vars           = "environments/production.tfvars"
+  tf_vars           = ["environments/production.tfvars", "environments/common.tfvars"]
 
 }

--- a/examples/tfvars/main.tf
+++ b/examples/tfvars/main.tf
@@ -1,0 +1,10 @@
+module "this" {
+  source            = "../.."
+  space_id          = "root"
+  repository_name   = "demo"
+  repository_branch = "main"
+  name              = "my awesome tfvars stack"
+  description       = "module test case for a stack with a variable file"
+  tf_vars           = "environments/production.tfvars"
+
+}

--- a/main.tf
+++ b/main.tf
@@ -192,6 +192,15 @@ resource "spacelift_environment_variable" "this" {
   write_only = each.value.sensitive
 }
 
+resource "spacelift_environment_variable" "tf_vars" {
+  count = var.tf_vars != null ? 1 : 0
+
+  stack_id   = spacelift_stack.this.id
+  name       = "TF_CLI_ARGS_plan"
+  value      = "-var-file=\"${var.tf_vars}\""
+  write_only = false
+}
+
 resource "spacelift_policy_attachment" "this" {
   for_each = var.policies
 

--- a/main.tf
+++ b/main.tf
@@ -200,11 +200,11 @@ resource "spacelift_environment_variable" "this" {
 }
 
 resource "spacelift_environment_variable" "tf_vars" {
-  count = var.tf_vars != null ? 1 : 0
+  count = length(var.tf_vars) > 0 ? 1 : 0
 
   stack_id   = spacelift_stack.this.id
   name       = "TF_CLI_ARGS_plan"
-  value      = "-var-file=\"${var.tf_vars}\""
+  value      = join(" ", [for var_file in var.tf_vars : "-var-file=\"${var_file}\""])
   write_only = false
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -259,9 +259,9 @@ variable "terragrunt_config" {
 }
 
 variable "tf_vars" {
-  type        = string
-  description = "Path to a variable file to use for the stack. Sets the TF_CLI_ARGS_plan environment variable to pass the var-file to OpenTofu/Terraform during plan. Not needed for apply since Spacelift applies the generated plan file."
-  default     = null
+  type        = list(string)
+  description = "Paths to variable files to use for the stack. Sets the TF_CLI_ARGS_plan environment variable to pass the var-files to OpenTofu/Terraform during plan. Not needed for apply since Spacelift applies the generated plan file."
+  default     = []
 }
 
 variable "tf_version" {

--- a/variables.tf
+++ b/variables.tf
@@ -237,6 +237,12 @@ variable "terragrunt_config" {
   }
 }
 
+variable "tf_vars" {
+  type        = string
+  description = "Path to a variable file to use for the stack. Sets the TF_CLI_ARGS_plan environment variable to pass the var-file to OpenTofu/Terraform during plan. Not needed for apply since Spacelift applies the generated plan file."
+  default     = null
+}
+
 variable "tf_version" {
   type        = string
   description = "The version of OpenTofu/Terraform for your stack to use. Defaults to latest."


### PR DESCRIPTION
## Summary
Adds a new optional `tf_vars` input that lets module consumers point their stack at a Terraform variable file:

```hcl
tf_vars = "environments/production.tfvars"
```

When set, the module creates a stack environment variable named `TF_CLI_ARGS_plan` with the value `-var-file="<path>"`, so OpenTofu/Terraform picks up the var-file during the plan phase.

## Why TF_CLI_ARGS_plan instead of TF_CLI_ARGS?
- `TF_CLI_ARGS` is prepended to **every** terraform command, including `terraform init`, which does not accept `-var-file` and fails with `flag provided but not defined: -var-file` during the run's initialization phase.
- The apply-scoped variant isn't needed either: Spacelift applies the saved plan file from the plan phase, and `terraform apply <planfile>` rejects `-var-file`. Variable values are already baked into the saved plan.

## Changes
- New optional `tf_vars` string variable (defaults to `null`, fully backwards compatible)
- New conditional `spacelift_environment_variable.tf_vars` resource, only created when `tf_vars` is set
- README example and inputs table updated

## Testing
- `tofu fmt -check` and `tofu validate` pass